### PR TITLE
Accept functions for highlight options

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -167,10 +167,6 @@
           d3.selectAll('.datamaps-hoverover').style('display', 'none');
         });
     }
-    
-    function moveToFront() {
-      this.parentNode.appendChild(this);
-    }
   }
 
   // Check if option is a function
@@ -585,8 +581,6 @@
   };
 
   Datamap.prototype.updateHighlights = function(element, d, options, data) {
-    var self = this;
-
     var previousAttributes = {
       'fill':  element.style('fill'),
       'stroke': element.style('stroke'),
@@ -603,7 +597,11 @@
 
     //as per discussion on https://github.com/markmarkoh/datamaps/issues/19
     if ( ! /MSIE/.test(navigator.userAgent) ) {
-      moveToFront.call(element);
+      moveToFront(element);
+    }
+
+    function moveToFront(element) {
+      element[0][0].parentNode.appendChild(element[0][0]);
     }
   };
 

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -3,7 +3,7 @@
 
   //save off default references
   var d3 = window.d3, topojson = window.topojson;
-  
+
   var defaultOptions = {
     scope: 'world',
     setProjection: setProjection,
@@ -14,34 +14,34 @@
       defaultFill: '#ABDDA4'
     },
     geographyConfig: {
-        dataUrl: null,
-        hideAntarctica: true,
-        borderWidth: 1,
-        borderColor: '#FDFDFD',
-        popupTemplate: function(geography, data) {
-          return '<div class="hoverinfo"><strong>' + geography.properties.name + '</strong></div>';
-        },
-        popupOnHover: true,
-        highlightOnHover: true,
-        highlightFillColor: '#FC8D59',
-        highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
-        highlightBorderWidth: 2
+      dataUrl: null,
+      hideAntarctica: true,
+      borderWidth: 1,
+      borderColor: '#FDFDFD',
+      popupTemplate: function(geography, data) {
+        return '<div class="hoverinfo"><strong>' + geography.properties.name + '</strong></div>';
+      },
+      popupOnHover: true,
+      highlightOnHover: true,
+      highlightFillColor: '#FC8D59',
+      highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
+      highlightBorderWidth: 2
     },
     bubblesConfig: {
-        borderWidth: 2,
-        borderColor: '#FFFFFF',
-        popupOnHover: true,
-        popupTemplate: function(geography, data) {
-          return '<div class="hoverinfo"><strong>' + data.name + '</strong></div>';
-        },
-        fillOpacity: 0.75,
-        animate: true,
-        highlightOnHover: true,
-        highlightFillColor: '#FC8D59',
-        highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
-        highlightBorderWidth: 2,
-        highlightFillOpacity: 0.85,
-        exitDelay: 100
+      borderWidth: 2,
+      borderColor: '#FFFFFF',
+      popupOnHover: true,
+      popupTemplate: function(geography, data) {
+        return '<div class="hoverinfo"><strong>' + data.name + '</strong></div>';
+      },
+      fillOpacity: 0.75,
+      animate: true,
+      highlightOnHover: true,
+      highlightFillColor: '#FC8D59',
+      highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
+      highlightBorderWidth: 2,
+      highlightFillOpacity: 0.85,
+      exitDelay: 100
     },
     arcConfig: {
       strokeColor: '#DD1C77',
@@ -87,14 +87,14 @@
   function addStyleBlock() {
     if ( d3.select('.datamaps-style-block').empty() ) {
       d3.select('head').append('style').attr('class', 'datamaps-style-block')
-      .html('.datamap path {stroke: #FFFFFF; stroke-width: 1px;} .datamaps-legend dt, .datamaps-legend dd { float: left; margin: 0 3px 0 0;} .datamaps-legend dd {width: 20px; margin-right: 6px; border-radius: 3px;} .datamaps-legend {padding-bottom: 20px; z-index: 1001; position: absolute; left: 4px; font-size: 12px; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;} .datamaps-hoverover {display: none; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; } .hoverinfo {padding: 4px; border-radius: 1px; background-color: #FFF; box-shadow: 1px 1px 5px #CCC; font-size: 12px; border: 1px solid #CCC; } .hoverinfo hr {border:1px dotted #CCC; }');
+        .html('.datamap path {stroke: #FFFFFF; stroke-width: 1px;} .datamaps-legend dt, .datamaps-legend dd { float: left; margin: 0 3px 0 0;} .datamaps-legend dd {width: 20px; margin-right: 6px; border-radius: 3px;} .datamaps-legend {padding-bottom: 20px; z-index: 1001; position: absolute; left: 4px; font-size: 12px; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;} .datamaps-hoverover {display: none; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; } .hoverinfo {padding: 4px; border-radius: 1px; background-color: #FFF; box-shadow: 1px 1px 5px #CCC; font-size: 12px; border: 1px solid #CCC; } .hoverinfo hr {border:1px dotted #CCC; }');
     }
   }
 
   function drawSubunits( data ) {
     var fillData = this.options.fills,
-        colorCodeData = this.options.data || {},
-        geoConfig = this.options.geographyConfig;
+      colorCodeData = this.options.data || {},
+      geoConfig = this.options.geographyConfig;
 
 
     var subunits = this.svg.select('g.datamaps-subunits');
@@ -215,7 +215,7 @@
 
   function handleArcs (layer, data, options) {
     var self = this,
-        svg = this.svg;
+      svg = this.svg;
 
     if ( !data || (data && !data.slice) ) {
       throw "Datamaps Error - arcs must be an array";
@@ -229,44 +229,44 @@
 
     arcs
       .enter()
-        .append('svg:path')
-        .attr('class', 'datamaps-arc')
-        .style('stroke-linecap', 'round')
-        .style('stroke', function(datum) {
-          if ( datum.options && datum.options.strokeColor) {
-            return datum.options.strokeColor;
-          }
-          return  options.strokeColor
-        })
-        .style('fill', 'none')
-        .style('stroke-width', function(datum) {
-          if ( datum.options && datum.options.strokeWidth) {
-            return datum.options.strokeWidth;
-          }
-          return options.strokeWidth;
-        })
-        .attr('d', function(datum) {
-            var originXY = self.latLngToXY(datum.origin.latitude, datum.origin.longitude);
-            var destXY = self.latLngToXY(datum.destination.latitude, datum.destination.longitude);
-            var midXY = [ (originXY[0] + destXY[0]) / 2, (originXY[1] + destXY[1]) / 2];
-            return "M" + originXY[0] + ',' + originXY[1] + "S" + (midXY[0] + (50 * options.arcSharpness)) + "," + (midXY[1] - (75 * options.arcSharpness)) + "," + destXY[0] + "," + destXY[1];
-        })
-        .transition()
-          .delay(100)
-          .style('fill', function() {
-            /*
-              Thank you Jake Archibald, this is awesome.
-              Source: http://jakearchibald.com/2013/animated-line-drawing-svg/
-            */
-            var length = this.getTotalLength();
-            this.style.transition = this.style.WebkitTransition = 'none';
-            this.style.strokeDasharray = length + ' ' + length;
-            this.style.strokeDashoffset = length;
-            this.getBoundingClientRect();
-            this.style.transition = this.style.WebkitTransition = 'stroke-dashoffset ' + options.animationSpeed + 'ms ease-out';
-            this.style.strokeDashoffset = '0';
-            return 'none';
-          })
+      .append('svg:path')
+      .attr('class', 'datamaps-arc')
+      .style('stroke-linecap', 'round')
+      .style('stroke', function(datum) {
+        if ( datum.options && datum.options.strokeColor) {
+          return datum.options.strokeColor;
+        }
+        return  options.strokeColor
+      })
+      .style('fill', 'none')
+      .style('stroke-width', function(datum) {
+        if ( datum.options && datum.options.strokeWidth) {
+          return datum.options.strokeWidth;
+        }
+        return options.strokeWidth;
+      })
+      .attr('d', function(datum) {
+        var originXY = self.latLngToXY(datum.origin.latitude, datum.origin.longitude);
+        var destXY = self.latLngToXY(datum.destination.latitude, datum.destination.longitude);
+        var midXY = [ (originXY[0] + destXY[0]) / 2, (originXY[1] + destXY[1]) / 2];
+        return "M" + originXY[0] + ',' + originXY[1] + "S" + (midXY[0] + (50 * options.arcSharpness)) + "," + (midXY[1] - (75 * options.arcSharpness)) + "," + destXY[0] + "," + destXY[1];
+      })
+      .transition()
+      .delay(100)
+      .style('fill', function() {
+        /*
+         Thank you Jake Archibald, this is awesome.
+         Source: http://jakearchibald.com/2013/animated-line-drawing-svg/
+         */
+        var length = this.getTotalLength();
+        this.style.transition = this.style.WebkitTransition = 'none';
+        this.style.strokeDasharray = length + ' ' + length;
+        this.style.strokeDashoffset = length;
+        this.getBoundingClientRect();
+        this.style.transition = this.style.WebkitTransition = 'stroke-dashoffset ' + options.animationSpeed + 'ms ease-out';
+        this.style.strokeDashoffset = '0';
+        return 'none';
+      })
 
     arcs.exit()
       .transition()
@@ -321,8 +321,8 @@
 
   function handleBubbles (layer, data, options ) {
     var self = this,
-        fillData = this.options.fills,
-        svg = this.svg;
+      fillData = this.options.fills,
+      svg = this.svg;
 
     if ( !data || (data && !data.slice) ) {
       throw "Datamaps Error - bubbles must be an array";
@@ -332,86 +332,86 @@
 
     bubbles
       .enter()
-        .append('svg:circle')
-        .attr('class', 'datamaps-bubble')
-        .attr('cx', function ( datum ) {
-          var latLng;
-          if ( datumHasCoords(datum) ) {
-            latLng = self.latLngToXY(datum.latitude, datum.longitude);
-          }
-          else if ( datum.centered ) {
-            latLng = self.path.centroid(svg.select('path.' + datum.centered).data()[0]);
-          }
-          if ( latLng ) return latLng[0];
-        })
-        .attr('cy', function ( datum ) {
-          var latLng;
-          if ( datumHasCoords(datum) ) {
-            latLng = self.latLngToXY(datum.latitude, datum.longitude);
-          }
-          else if ( datum.centered ) {
-            latLng = self.path.centroid(svg.select('path.' + datum.centered).data()[0]);
-          }
-          if ( latLng ) return latLng[1];;
-        })
-        .attr('r', 0) //for animation purposes
-        .attr('data-info', function(d) {
-          return JSON.stringify(d);
-        })
-        .style('stroke', options.borderColor)
-        .style('stroke-width', options.borderWidth)
-        .style('fill-opacity', options.fillOpacity)
-        .style('fill', function ( datum ) {
-          var fillColor = fillData[ datum.fillKey ];
-          return fillColor || fillData.defaultFill;
-        })
-        .on('mouseover', function ( datum ) {
-          var $this = d3.select(this);
+      .append('svg:circle')
+      .attr('class', 'datamaps-bubble')
+      .attr('cx', function ( datum ) {
+        var latLng;
+        if ( datumHasCoords(datum) ) {
+          latLng = self.latLngToXY(datum.latitude, datum.longitude);
+        }
+        else if ( datum.centered ) {
+          latLng = self.path.centroid(svg.select('path.' + datum.centered).data()[0]);
+        }
+        if ( latLng ) return latLng[0];
+      })
+      .attr('cy', function ( datum ) {
+        var latLng;
+        if ( datumHasCoords(datum) ) {
+          latLng = self.latLngToXY(datum.latitude, datum.longitude);
+        }
+        else if ( datum.centered ) {
+          latLng = self.path.centroid(svg.select('path.' + datum.centered).data()[0]);
+        }
+        if ( latLng ) return latLng[1];;
+      })
+      .attr('r', 0) //for animation purposes
+      .attr('data-info', function(d) {
+        return JSON.stringify(d);
+      })
+      .style('stroke', options.borderColor)
+      .style('stroke-width', options.borderWidth)
+      .style('fill-opacity', options.fillOpacity)
+      .style('fill', function ( datum ) {
+        var fillColor = fillData[ datum.fillKey ];
+        return fillColor || fillData.defaultFill;
+      })
+      .on('mouseover', function ( datum ) {
+        var $this = d3.select(this);
 
-          if (options.highlightOnHover) {
-            //save all previous attributes for mouseout
-            var previousAttributes = {
-              'fill':  $this.style('fill'),
-              'stroke': $this.style('stroke'),
-              'stroke-width': $this.style('stroke-width'),
-              'fill-opacity': $this.style('fill-opacity')
-            };
+        if (options.highlightOnHover) {
+          //save all previous attributes for mouseout
+          var previousAttributes = {
+            'fill':  $this.style('fill'),
+            'stroke': $this.style('stroke'),
+            'stroke-width': $this.style('stroke-width'),
+            'fill-opacity': $this.style('fill-opacity')
+          };
 
-            $this
-              .style('fill', options.highlightFillColor)
-              .style('stroke', options.highlightBorderColor)
-              .style('stroke-width', options.highlightBorderWidth)
-              .style('fill-opacity', options.highlightFillOpacity)
-              .attr('data-previousAttributes', JSON.stringify(previousAttributes));
+          $this
+            .style('fill', options.highlightFillColor)
+            .style('stroke', options.highlightBorderColor)
+            .style('stroke-width', options.highlightBorderWidth)
+            .style('fill-opacity', options.highlightFillOpacity)
+            .attr('data-previousAttributes', JSON.stringify(previousAttributes));
+        }
+
+        if (options.popupOnHover) {
+          self.updatePopup($this, datum, options, svg);
+        }
+      })
+      .on('mouseout', function ( datum ) {
+        var $this = d3.select(this);
+
+        if (options.highlightOnHover) {
+          //reapply previous attributes
+          var previousAttributes = JSON.parse( $this.attr('data-previousAttributes') );
+          for ( var attr in previousAttributes ) {
+            $this.style(attr, previousAttributes[attr]);
           }
+        }
 
-          if (options.popupOnHover) {
-            self.updatePopup($this, datum, options, svg);
-          }
-        })
-        .on('mouseout', function ( datum ) {
-          var $this = d3.select(this);
-
-          if (options.highlightOnHover) {
-            //reapply previous attributes
-            var previousAttributes = JSON.parse( $this.attr('data-previousAttributes') );
-            for ( var attr in previousAttributes ) {
-              $this.style(attr, previousAttributes[attr]);
-            }
-          }
-
-          d3.selectAll('.datamaps-hoverover').style('display', 'none');
-        })
-        .transition().duration(400)
-          .attr('r', function ( datum ) {
-            return datum.radius;
-          });
+        d3.selectAll('.datamaps-hoverover').style('display', 'none');
+      })
+      .transition().duration(400)
+      .attr('r', function ( datum ) {
+        return datum.radius;
+      });
 
     bubbles.exit()
       .transition()
-        .delay(options.exitDelay)
-        .attr("r", 0)
-        .remove();
+      .delay(options.exitDelay)
+      .attr("r", 0)
+      .remove();
 
     function datumHasCoords (datum) {
       return typeof datum !== 'undefined' && typeof datum.latitude !== 'undefined' && typeof datum.longitude !== 'undefined';
@@ -431,14 +431,14 @@
     return obj;
   }
   /**************************************
-             Public Functions
-  ***************************************/
+   Public Functions
+   ***************************************/
 
   function Datamap( options ) {
 
     if ( typeof d3 === 'undefined' || typeof topojson === 'undefined' ) {
       throw new Error('Include d3.js (v3.0.3 or greater) and topojson on this page before creating a new map');
-   }
+    }
 
     //set options for global use
     this.options = defaults(options, defaultOptions);
@@ -491,49 +491,49 @@
 
     return this;
 
-      function draw (data) {
-        // if fetching remote data, draw the map first then call `updateChoropleth`
-        if ( self.options.dataUrl ) {
-          //allow for csv or json data types
-          d3[self.options.dataType](self.options.dataUrl, function(data) {
-            //in the case of csv, transform data to object
-            if ( self.options.dataType === 'csv' && (data && data.slice) ) {
-              var tmpData = {};
-              for(var i = 0; i < data.length; i++) {
-                tmpData[data[i].id] = data[i];
-              } 
-              data = tmpData;
+    function draw (data) {
+      // if fetching remote data, draw the map first then call `updateChoropleth`
+      if ( self.options.dataUrl ) {
+        //allow for csv or json data types
+        d3[self.options.dataType](self.options.dataUrl, function(data) {
+          //in the case of csv, transform data to object
+          if ( self.options.dataType === 'csv' && (data && data.slice) ) {
+            var tmpData = {};
+            for(var i = 0; i < data.length; i++) {
+              tmpData[data[i].id] = data[i];
             }
-            Datamaps.prototype.updateChoropleth.call(self, data);
-          });
-        }
-        drawSubunits.call(self, data);
-        handleGeographyConfig.call(self);
-
-        if ( self.options.geographyConfig.popupOnHover || self.options.bubblesConfig.popupOnHover) {
-          hoverover = d3.select( self.options.element ).append('div')
-            .attr('class', 'datamaps-hoverover')
-            .style('z-index', 10001)
-            .style('position', 'absolute');
-        }
-
-        //fire off finished callback
-        self.options.done(self);
+            data = tmpData;
+          }
+          Datamaps.prototype.updateChoropleth.call(self, data);
+        });
       }
+      drawSubunits.call(self, data);
+      handleGeographyConfig.call(self);
+
+      if ( self.options.geographyConfig.popupOnHover || self.options.bubblesConfig.popupOnHover) {
+        hoverover = d3.select( self.options.element ).append('div')
+          .attr('class', 'datamaps-hoverover')
+          .style('z-index', 10001)
+          .style('position', 'absolute');
+      }
+
+      //fire off finished callback
+      self.options.done(self);
+    }
   };
   /**************************************
-                TopoJSON
-  ***************************************/
+   TopoJSON
+   ***************************************/
   Datamap.prototype.worldTopo = '__WORLD__';
   Datamap.prototype.usaTopo = '__USA__';
 
   /**************************************
-                Utilities
-  ***************************************/
+   Utilities
+   ***************************************/
 
-  //convert lat/lng coords to X / Y coords
+    //convert lat/lng coords to X / Y coords
   Datamap.prototype.latLngToXY = function(lat, lng) {
-     return this.projection([lng, lat]);
+    return this.projection([lng, lat]);
   };
 
   //add <g> layer to root SVG
@@ -575,7 +575,7 @@
         svg
           .selectAll('.' + subunit)
           .transition()
-            .style('fill', color);
+          .style('fill', color);
       }
     }
   };
@@ -658,7 +658,7 @@
   };
 
   // http://jsperf.com/alternative-isfunction-implementations/4
-  Datamap.prototype.isFunction = function(value){
+  function isFunction(value){
     return value && typeof(value) == 'function';
   };
 

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -189,6 +189,14 @@
     }
   }
 
+  // Check if option is a function
+  function getOptionValue(option, d, data){
+    if(isFunction(option))
+      return option(d, data);
+
+    return option;
+  }
+
   //plugin to add a simple map legend
   function addLegend(layer, data, options) {
     data = data || {};

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -644,6 +644,11 @@
     }
   };
 
+  // http://jsperf.com/alternative-isfunction-implementations/4
+  Datamap.prototype.isFunction = function(value){
+    return value && typeof(value) == 'function';
+  };
+
   // expose library
   if ( typeof define === "function" && define.amd ) {
     define( "datamaps", function(require) { d3 = require('d3'); topojson = require('topojson'); return Datamap; } );

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -143,26 +143,10 @@
       svg.selectAll('.datamaps-subunit')
         .on('mouseover', function(d) {
           var $this = d3.select(this);
+          var data = JSON.parse($this.attr('data-info'));
 
-          if ( options.highlightOnHover ) {
-            var previousAttributes = {
-              'fill':  $this.style('fill'),
-              'stroke': $this.style('stroke'),
-              'stroke-width': $this.style('stroke-width'),
-              'fill-opacity': $this.style('fill-opacity')
-            };
-
-            $this
-              .style('fill', options.highlightFillColor)
-              .style('stroke', options.highlightBorderColor)
-              .style('stroke-width', options.highlightBorderWidth)
-              .style('fill-opacity', options.highlightFillOpacity)
-              .attr('data-previousAttributes', JSON.stringify(previousAttributes));
-
-            //as per discussion on https://github.com/markmarkoh/datamaps/issues/19
-            if ( ! /MSIE/.test(navigator.userAgent) ) {
-             moveToFront.call(this);
-            }
+          if ( getOptionValue(options.highlightOnHover, d, data) ) {
+            self.updateHighlights($this, d, options, data);
           }
 
           if ( options.popupOnHover ) {
@@ -597,6 +581,29 @@
           .transition()
             .style('fill', color);
       }
+    }
+  };
+
+  Datamap.prototype.updateHighlights = function(element, d, options, data) {
+    var self = this;
+
+    var previousAttributes = {
+      'fill':  element.style('fill'),
+      'stroke': element.style('stroke'),
+      'stroke-width': element.style('stroke-width'),
+      'fill-opacity': element.style('fill-opacity')
+    };
+
+    element
+      .style('fill', getOptionValue(options.highlightFillColor, d, data))
+      .style('stroke', getOptionValue(options.highlightBorderColor, d, data))
+      .style('stroke-width', getOptionValue(options.highlightBorderWidth, d, data))
+      .style('fill-opacity', getOptionValue(options.highlightFillOpacity, d, data))
+      .attr('data-previousAttributes', JSON.stringify(previousAttributes));
+
+    //as per discussion on https://github.com/markmarkoh/datamaps/issues/19
+    if ( ! /MSIE/.test(navigator.userAgent) ) {
+      moveToFront.call(element);
     }
   };
 


### PR DESCRIPTION
First attempt at accepting both strings and functions as options for highlights, if workable can easily be extendable to more options(popup, etc.).

Allows for the following options to be functions:
- `highlightOnHover`
- `highlightFillColor`
- `highlightBorderColor`
- `highlightBorderWidth`

Each function will be passed `d` and the `data` following D3.js syntax.

Should potentially also solve issue #24.

@markmarkoh would love your feedback on this POC.