### PR TITLE
prevent flickering popups for elements that has positional styles

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -608,12 +608,12 @@
       var position = d3.mouse(this);
       d3.select(self.svg[0][0].parentNode).select('.datamaps-hoverover')
         .style('top', ( (position[1] + 30)) + "px")
+        .style('left', ( position[0]) + "px")
         .html(function() {
           var data = JSON.parse(element.attr('data-info'));
           //if ( !data ) return '';
           return options.popupTemplate(d, data);
-        })
-        .style('left', ( position[0]) + "px");
+        });
     });
 
     d3.select(self.svg[0][0].parentNode).select('.datamaps-hoverover').style('display', 'block');


### PR DESCRIPTION
In the updatePopup, the popup position of x and y position is
wrapped between the html. If the elements have any style that changes
the position, padding, or margin, you'll get a flickering effect on the
mouse over.

This will fix that by setting the positions before rendering out the
html.
