### PR TITLE
Add dataJson option in geographyConfig

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -507,7 +507,7 @@
       });
     }
     else {
-      draw( this[options.scope + 'Topo'] || JSON.parse(options.geographyConfig.dataJson));
+      draw( this[options.scope + 'Topo'] || options.geographyConfig.dataJson);
     }
 
     return this;


### PR DESCRIPTION
This PR allows the use `dataJson` in `geographyConfig` to specify a custom topojson file as a string, instead of having to use `dataUrl` and link to an external file. This is especially useful in generating standalone html files with no dependencies.
