### PR TITLE
Docs- typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Datamaps
 Datamaps is intended to provide some data visualizations based on geographical data. It's SVG-based, can scale to any screen size, and includes everything inside of 1 script file.
 It heavily relies on the amazing [D3.js](https://github.com/mbostock/d3) library.
 
-Out of the box in includes support for choropleths and bubble maps (see [demos](http://datamaps.github.io)), but it's not limited to just that. Its new plugin system allows for the addition of any type of visualization over the map.
+Out of the box it includes support for choropleths and bubble maps (see [demos](http://datamaps.github.io)), but it's not limited to just that. Its new plugin system allows for the addition of any type of visualization over the map.
 
 ##### For feature requests, open an issue!
 


### PR DESCRIPTION
Thanks for building such a great tool! It's exactly the visualization I was looking for on a current project to map programming languages by country. 

I found a super minor typo in the README: 
![image](https://cloud.githubusercontent.com/assets/7017045/6254418/43f9e424-b75d-11e4-87f2-cffdc3deca58.png)

![image](https://cloud.githubusercontent.com/assets/7017045/6254411/3cf1e88e-b75d-11e4-8c80-73711439d975.png)
