### PR TITLE
Add CommonJS export as alternative to AMD & global state.

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -759,7 +759,12 @@
   };
 
   // expose library
-  if ( typeof define === "function" && define.amd ) {
+  if (typeof exports === 'object') {
+    d3 = require('d3');
+    topojson = require('topojson');
+    module.exports = Datamap;
+  }
+  else if ( typeof define === "function" && define.amd ) {
     define( "datamaps", function(require) { d3 = require('d3'); topojson = require('topojson'); return Datamap; } );
   }
   else {


### PR DESCRIPTION
Currently it's only possible to include the project with AMD & a global include. There should be an option for CommonJS users.