### PR TITLE
Sync bower with npm dependencies during build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,11 @@ module.exports = function(grunt) {
     },
     clean: {
       release: ['.dist/datamaps.*.js']
+    },
+    sync: {
+      options: {
+        include: ['name', 'version', 'main', 'dependencies']
+      }
     }
   });
 
@@ -76,9 +81,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-text-replace');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-sync-pkg');
 
 
   grunt.registerTask('dev', ['replace']);
-  grunt.registerTask('build', ['replace', 'uglify:dist', 'copy']);
+  grunt.registerTask('build', ['replace', 'uglify:dist', 'copy', 'sync']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "datamaps",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "homepage": "https://github.com/markmarkoh/datamaps",
   "authors": [
     "Mark DiMarco<markmarkoh@gmail.com>"
@@ -9,7 +9,9 @@
     "Dave Long (dave@davejlong.com)"
   ],
   "description": "Interactive maps for data visualizations. Bundled into a single Javascript file.",
-  "main": "dist/datamaps.all.js",
+  "main": [
+    "dist/datamaps.all.js"
+  ],
   "keywords": [
     "USA",
     "World",
@@ -26,7 +28,7 @@
     "public"
   ],
   "dependencies": {
-    "d3": "~3.3.8",
-    "topojson": "~1.4.3"
+    "d3": "^3.5.5",
+    "topojson": "^1.6.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "topojson": "^1.6.19"
   },
   "devDependencies": {
-    "grunt-replace": "~0.4.4",
     "grunt": "~0.4.1",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jasmine": "~0.5.2",
-    "grunt-text-replace": "~0.3.6",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.4.4",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt-replace": "~0.4.4",
+    "grunt-sync-pkg": "^0.1.2",
+    "grunt-text-replace": "~0.3.6"
   }
 }


### PR DESCRIPTION
As referenced in #157. I bumped into this while using `bower install` and not getting up-to-date child dependencies. I've added a grunt module/task to sync version properties from `package.json`. I suppose a discussion could be had as to the value of supporting bower as well as npm, since they are basically interchangeable, but for now this should save some folks from tripping up.