### PR TITLE
Add amd module dependency array

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -1043,7 +1043,12 @@
     module.exports = Datamap;
   }
   else if ( typeof define === "function" && define.amd ) {
-    define( "datamaps", function(require) { d3 = require('d3'); topojson = require('topojson'); return Datamap; } );
+    define( "datamaps", ["require", "d3", "topojson"], function(require) {
+      d3 = require('d3');
+      topojson = require('topojson');
+
+      return Datamap;
+    });
   }
   else {
     window.Datamap = window.Datamaps = Datamap;


### PR DESCRIPTION
This fixes the `Uncaught Error: Module name "d3" has not been loaded yet for context: _`.

The problem was missing dependency array in the AMD module `define` function params. Can be easily checked by placing `console.log(deps);` between for ex. [these](https://github.com/jrburke/requirejs/blob/master/require.js#L2083-L2084) lines in your development `require.js`. You'll see that without that array in the params the only thing required (figured out by `requirejs`) is the `require` module itself.