### PR TITLE
add option to update bubbles in place when lat/lng unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,15 +474,19 @@ If the aspect ratio of your custom map is not the default `16:9` (`0.5625`), you
         borderWidth: 2,
         borderColor: '#FFFFFF',
         popupOnHover: true,
+        radius: null,
         popupTemplate: function(geography, data) {
-          return '&lt;div class="hoverinfo"&gt;&lt;strong&gt;' + data.name + '&lt;/strong&gt;&lt;/div&gt;';
+          return '<div class="hoverinfo"><strong>' + data.name + '</strong></div>';
         },
         fillOpacity: 0.75,
+        animate: true,
         highlightOnHover: true,
         highlightFillColor: '#FC8D59',
         highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
         highlightBorderWidth: 2,
-        highlightFillOpacity: 0.85
+        highlightFillOpacity: 0.85,
+        exitDelay: 100,
+        keyFn: JSON.stringify
     },
     arcConfig: {
       strokeColor: '#DD1C77',

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ If the aspect ratio of your custom map is not the default `16:9` (`0.5625`), you
         highlightBorderWidth: 2,
         highlightFillOpacity: 0.85,
         exitDelay: 100,
-        keyFn: JSON.stringify
+        key: JSON.stringify
     },
     arcConfig: {
       strokeColor: '#DD1C77',

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -50,7 +50,7 @@
         highlightBorderWidth: 2,
         highlightFillOpacity: 0.85,
         exitDelay: 100,
-        keyFn: JSON.stringify
+        key: JSON.stringify
     },
     arcConfig: {
       strokeColor: '#DD1C77',
@@ -441,7 +441,7 @@
       throw "Datamaps Error - bubbles must be an array";
     }
 
-    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, options.keyFn );
+    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, options.key );
 
     bubbles
       .enter()

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -49,7 +49,8 @@
         highlightBorderColor: 'rgba(250, 15, 160, 0.2)',
         highlightBorderWidth: 2,
         highlightFillOpacity: 0.85,
-        exitDelay: 100
+        exitDelay: 100,
+        update: false
     },
     arcConfig: {
       strokeColor: '#DD1C77',
@@ -440,7 +441,7 @@
       throw "Datamaps Error - bubbles must be an array";
     }
 
-    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, JSON.stringify );
+    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, getBubbleKey(options) );
 
     bubbles
       .enter()
@@ -523,10 +524,12 @@
 
           d3.selectAll('.datamaps-hoverover').style('display', 'none');
         })
-        .transition().duration(400)
-          .attr('r', function ( datum ) {
-            return val(datum.radius, options.radius, datum);
-          });
+
+    bubbles.transition()
+      .duration(400)
+      .attr('r', function ( datum ) {
+        return val(datum.radius, options.radius, datum);
+      });
 
     bubbles.exit()
       .transition()
@@ -536,6 +539,19 @@
 
     function datumHasCoords (datum) {
       return typeof datum !== 'undefined' && typeof datum.latitude !== 'undefined' && typeof datum.longitude !== 'undefined';
+    }
+
+    function getBubbleKey (options) {
+      if (options.updateBubbles) {
+        return function(d) { 
+          return JSON.stringify({
+            latitude: d.latitude,
+            longitude: d.longitude
+          });
+        }
+      } else {
+        return JSON.stringify;
+      }
     }
 
   }

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -542,7 +542,7 @@
     }
 
     function getBubbleKey (options) {
-      if (options.updateBubbles) {
+      if (options.update) {
         return function(d) { 
           return JSON.stringify({
             latitude: d.latitude,

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -50,7 +50,7 @@
         highlightBorderWidth: 2,
         highlightFillOpacity: 0.85,
         exitDelay: 100,
-        update: false
+        keyFn: JSON.stringify
     },
     arcConfig: {
       strokeColor: '#DD1C77',
@@ -441,7 +441,7 @@
       throw "Datamaps Error - bubbles must be an array";
     }
 
-    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, getBubbleKey(options) );
+    var bubbles = layer.selectAll('circle.datamaps-bubble').data( data, options.keyFn );
 
     bubbles
       .enter()
@@ -540,20 +540,6 @@
     function datumHasCoords (datum) {
       return typeof datum !== 'undefined' && typeof datum.latitude !== 'undefined' && typeof datum.longitude !== 'undefined';
     }
-
-    function getBubbleKey (options) {
-      if (options.update) {
-        return function(d) { 
-          return JSON.stringify({
-            latitude: d.latitude,
-            longitude: d.longitude
-          });
-        }
-      } else {
-        return JSON.stringify;
-      }
-    }
-
   }
 
   //stolen from underscore.js


### PR DESCRIPTION
I have bubble values that change slightly each year. The default behavior of `.bubbles([])` is to replace all, which makes it hard to notice small changes. This adds an option to grow/shrink existing bubbles to the new size. Click the year buttons to see the difference:

[Original behavior](http://embed.plnkr.co/YhzplFyYkupe88E2bVjz/preview) / [New behavior](http://embed.plnkr.co/l181GzZbRL8YYZesDBg9/preview)

Thanks for the great library!