### PR TITLE
Updates the data-info of a bubble on transition

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -538,6 +538,11 @@
       .duration(400)
       .attr('r', function ( datum ) {
         return val(datum.radius, options.radius, datum);
+      })
+    .transition()
+      .duration(0)
+      .attr('data-info', function(d) {
+        return JSON.stringify(d);
       });
 
     bubbles.exit()


### PR DESCRIPTION
Supporting [pull request #225](https://github.com/markmarkoh/datamaps/pull/225).

If we have bubbles with a custom key, then when the bubble transitions, the data-info isn't updated (and so the hover-over information is unchanged).

Example:

**Key:**
```
    bubbleKey: function (d) {
        return JSON.stringify({lat: d.latitude, lng: d.longitude, name: d.name});
    },
```

**Bubble:**
```
    {
        name: 'Test',
        radius: 30,
        size: 'Big!',
        fillKey: 'USA',
        latitude: 10.1,
        longitude: -5.4
    }
```

**New Bubble:**
```
    {
        name: 'Test',
        radius: 5,
        size: 'Small!',
        fillKey: 'USA',
        latitude: 10.1,
        longitude: -5.4
    }
```

**Template:**
```
    popupTemplate: function (geo, data) {
        return ['<div class="hoverinfo">' + data.name,
                '<br/>Size: ' + data.size + '',
                '</div>'].join('');
    }
```

When we initially call `bubbles()` with the first bubble, we have a hover-over tooltip stating `Size: Big!`. If we then push the new bubble, we'll have the `radius` reduced, but the bubble will not be redrawn (thanks to pull request #225 and the `bubbleKey` that we have defined). The hover-over, however, will still say `Size: Big!`, where it should say `Size: Small!`.

This change just adds a new instant transition on `bubbles` which re-stringify's the data into `data-info`, thus updated the hover-over text.