### PR TITLE
Update 3-letter codes for Kosovo and Northern Cyprus. 

### DIFF
--- a/src/js/data/world.topo.json
+++ b/src/js/data/world.topo.json
@@ -500,7 +500,7 @@
                 "properties": {
                     "name": "Northern Cyprus"
                 },
-                "id": "-99",
+                "id": "CYP",
                 "arcs": [
                     [216, 217]
                 ]
@@ -1041,7 +1041,7 @@
                 "properties": {
                     "name": "Kosovo"
                 },
-                "id": "-99",
+                "id": "XKX",
                 "arcs": [
                     [-18, 405, 406, 407]
                 ]


### PR DESCRIPTION
Commonly accepted 3-letter codes for Kosovo and Northern Cyprus are XKX and CYP. Right now it's impossible to color them on the map, since they all have an ID of -99. Even if the codes aren't correct, it's better to have it this way than -99