### PR TITLE
Only add SVG container when necessary

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -717,7 +717,7 @@
     this.options.arcConfig = defaults(options.arcConfig, defaultOptions.arcConfig);
 
     // Add the SVG container
-    if ( d3.select( this.options.element ).select('svg').length > 0 ) {
+    if ( d3.select( this.options.element ).select('svg').empty() ) {
       addContainer.call(this, this.options.element, this.options.height, this.options.width );
     }
 


### PR DESCRIPTION
I noticed this when trying to get datamaps to work with d3 4.x.  

I'm a bit confused about why this is written as `if (selection.length > 0)`, as that is opposite of the expected behavior of "add unless already exists" (unless I'm misunderstanding the intent here).  However, any incorrect behavior was masked in most cases because even if there is no `svg` element the selection will still have one null element.

This PR fixes the logic, and makes it d3 4.x-compatible.