### PR TITLE
Fix Mouseout not triggering in IE Edge

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -260,7 +260,7 @@
               .attr('data-previousAttributes', JSON.stringify(previousAttributes));
 
             // As per discussion on https://github.com/markmarkoh/datamaps/issues/19
-            if ( ! /((MSIE)|(Trident))/.test(navigator.userAgent) ) {
+            if ( ! /((MSIE)|(Trident)|(Edge))/.test(navigator.userAgent) ) {
              moveToFront.call(this);
             }
           }


### PR DESCRIPTION
Add Edge to moveToFront regex check
Credit to @nosro and @petersjoo
fixes #341 