### PR TITLE
fix missing country codes in worldmap

### DIFF
--- a/src/js/data/world.topo.json
+++ b/src/js/data/world.topo.json
@@ -500,7 +500,7 @@
                 "properties": {
                     "name": "Northern Cyprus"
                 },
-                "id": "-99",
+                "id": "CYN",
                 "arcs": [
                     [216, 217]
                 ]
@@ -1041,7 +1041,7 @@
                 "properties": {
                     "name": "Kosovo"
                 },
-                "id": "-99",
+                "id": "KOS",
                 "arcs": [
                     [-18, 405, 406, 407]
                 ]
@@ -1654,7 +1654,7 @@
                 "properties": {
                     "name": "Somaliland"
                 },
-                "id": "-99",
+                "id": "SOL",
                 "arcs": [
                     [-263, -231, 559, 560]
                 ]


### PR DESCRIPTION
updated codes are:
Kosovo -> KOS
Northern Cyprus -> CYN
Somaliland -> SOL

Fixes: #376, #360 

refer issue for background and reason.