### PR TITLE
Fix USA label centering issue

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -502,6 +502,9 @@
     this.svg.selectAll(".datamaps-subunit")
       .attr("data-foo", function(d) {
         var center = self.path.centroid(d);
+        if ( d.properties.iso === 'USA' ) {
+            center = self.projection([-98.58333, 39.83333])
+        }
         var xOffset = 7.5, yOffset = 5;
 
         if ( ["FL", "KY", "MI"].indexOf(d.id) > -1 ) xOffset = -2.5;


### PR DESCRIPTION
The current label for the USA is in Canada; this pull request moves the label to be in the center of the continental United States. This fix is the same as was applied to the bubble centering.