### PR TITLE
Issue # 439: Add dataUrl error handling callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ If the aspect ratio of your custom map is not the default `16:9` (`0.5625`), you
     width: null, // If not null, datamaps will grab the width of 'element',
     responsive: false, // If true, call `resize()` on the map object when it should adjust it's size
     done: function() {}, // Callback when the map is done drawing
+    error: function() {}, // Callback when the map cannot fetch the dataUrl
     fills: {
       defaultFill: '#ABDDA4' // The keys in this object map to the "fillKey" of [data] or [bubbles]
     },

--- a/src/examples/custom-map-data-error-handling.html
+++ b/src/examples/custom-map-data-error-handling.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+  <script src="http://d3js.org/d3.v3.min.js"></script>
+  <script src="http://d3js.org/topojson.v1.min.js"></script>
+  <!-- I recommend you host this file on your own, since this will change without warning -->
+  <script src="/src/rel/datamaps.world.js"></script>
+  <h2>Custom Map Data Error Handling</h2>
+  <div id="errorContainer" style="color: green; padding: 10px; font-size: 16px;" />
+  <div id="container1" style="position: relative; width: 500px; height: 450px;"></div>
+  <script>
+    //basic map config with custom fills, mercator projection
+  var map = new Datamap({
+    element: document.getElementById('container1'),
+    geographyConfig: {
+      dataUrl: 'NON_EXISTANT.json'
+    },
+    error: function(e) {
+      const domEl = document.getElementById('errorContainer');
+      domEl.innerText = `Caught error when fetching data: ${e}`;
+    }
+  });
+  </script>
+</body>

--- a/src/examples/custom-map-data-error-handling.html
+++ b/src/examples/custom-map-data-error-handling.html
@@ -3,22 +3,20 @@
 <body>
   <script src="http://d3js.org/d3.v3.min.js"></script>
   <script src="http://d3js.org/topojson.v1.min.js"></script>
-  <!-- I recommend you host this file on your own, since this will change without warning -->
   <script src="/src/rel/datamaps.world.js"></script>
   <h2>Custom Map Data Error Handling</h2>
   <div id="errorContainer" style="color: green; padding: 10px; font-size: 16px;" />
   <div id="container1" style="position: relative; width: 500px; height: 450px;"></div>
   <script>
-    //basic map config with custom fills, mercator projection
-  var map = new Datamap({
-    element: document.getElementById('container1'),
-    geographyConfig: {
-      dataUrl: 'NON_EXISTANT.json'
-    },
-    error: function(e) {
-      const domEl = document.getElementById('errorContainer');
-      domEl.innerText = `Caught error when fetching data: ${e}`;
-    }
-  });
+    var map = new Datamap({
+      element: document.getElementById('container1'),
+      geographyConfig: {
+        dataUrl: 'NON_EXISTANT.json'
+      },
+      error: function(e) {
+        const domEl = document.getElementById('errorContainer');
+        domEl.innerText = `Caught error when fetching data: ${e}`;
+      }
+    });
   </script>
 </body>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,7 @@ declare interface DataMapOptions {
         path: d3.geo.Path;
         projection: d3.geo.Projection;
     }) => void;
+    error?: (error: any) => void;
     responsive?: boolean;
     projection?: string;
     height?: null | number;

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -13,6 +13,7 @@
     dataType: 'json',
     data: {},
     done: function() {},
+    error: function() {},
     fills: {
       defaultFill: '#ABDDA4'
     },
@@ -765,7 +766,10 @@
     // If custom URL for topojson data, retrieve it and render
     if ( options.geographyConfig.dataUrl ) {
       d3.json( options.geographyConfig.dataUrl, function(error, results) {
-        if ( error ) throw new Error(error);
+        if ( error ) {
+          self.options.error(error);
+          return;
+        }
         self.customTopo = results;
         draw( results );
       });


### PR DESCRIPTION
Issue: https://github.com/markmarkoh/datamaps/issues/439

This PR adds a callback function to the Datamaps constructor which is called when the `dataUrl` supplied with the `geographyConfig` fails to load.

This will allow for better error handling.