### PR TITLE
Add ability to configure borders with custom data

### DIFF
--- a/src/examples/custom-map-data.html
+++ b/src/examples/custom-map-data.html
@@ -4,52 +4,48 @@
   <script src="http://d3js.org/d3.v3.min.js"></script>
   <script src="http://d3js.org/topojson.v1.min.js"></script>
   <!-- I recommend you host this file on your own, since this will change without warning -->
-  <script src="/src/rel/datamaps.usa.js?v=1"></script>
+  <script src="../../src/rel/datamaps.usa.js?v=1"></script>
   <h2>Datamaps New York Test</h2>
-  <p><a href="http://datamaps.github.io/">DataMaps Project Homepage</a>, Counties referred to by their <a href="http://en.wikipedia.org/wiki/List_of_counties_in_New_York">FIPS code</a></p>
-  <div id="container1" style="position: relative; width: 500px; height: 450px;"></div>
- 
-     
-     <script>
-       //basic map config with custom fills, mercator projection
-      var map = new Datamap({
-        scope: 'subunits-ny',
-        element: document.getElementById('container1'),
-        projection: '',
-        geographyConfig: {
-          dataUrl: 'test.json'
-        },
-        setProjection: function(element) {
-          var projection = d3.geo.equirectangular()
-            .center([-72, 43])
-            .rotate([4.4, 0])
-            .scale(4000)
-            .translate([element.offsetWidth / 2, element.offsetHeight / 2]);
-          var path = d3.geo.path()
-            .projection(projection);
-          
-          return {path: path, projection: projection};
-        },
-        fills: {
-          defaultFill: '#f0af0a',
-          lt50: 'rgba(0,244,244,0.9)',
-          gt50: 'red'
-        },
+  <p>
+    <a href="http://datamaps.github.io/">DataMaps Project Homepage</a>, Counties referred to by their <a href="http://en.wikipedia.org/wiki/List_of_counties_in_New_York">FIPS code</a>
+  </p>
+  <div id="container1" style="position: relative; width: 500px; height: 450px;"></div>    
+  <script>
+    // Basic map config with custom data with fills and strokes.
+    var map = new Datamap({
+      scope: 'subunits-ny',
+      element: document.getElementById('container1'),
+      projection: '',
+      geographyConfig: {
+        dataUrl: './test.json'
+      },
+      setProjection: function(element) {
+        var projection = d3.geo.equirectangular()
+          .center([-72, 43])
+          .rotate([4.4, 0])
+          .scale(4000)
+          .translate([element.offsetWidth / 2, element.offsetHeight / 2]);
+        var path = d3.geo.path()
+          .projection(projection);
         
-        data: {
-          '071': {fillKey: 'lt50' },
-          '001': {fillKey: 'gt50' }       
-        }
-      });
+        return {path: path, projection: projection};
+      },
+      fills: {
+        defaultFill: '#f0af0a',
+        lt50: 'rgba(0,244,244,0.9)',
+        gt50: 'red'
+      },
+      data: {
+        '071': { fillKey: 'lt50', borderColor: 'red' },
+        '001': { fillKey: 'gt50', borderColor: 'purple' }       
+      }
+    });
 
-      map.bubbles([
-        {longitude: -77, latitude: 43, radius: 30, fillKey: 'gt50'}
-      ], {
-        popupOnHover: false,
-        highlightOnHover: false
-      });
-
-
-      
-     </script>
+    map.bubbles([
+      {longitude: -77, latitude: 43, radius: 30, fillKey: 'gt50'}
+    ], {
+      popupOnHover: false,
+      highlightOnHover: false
+    });
+  </script>
 </body>

--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -227,9 +227,21 @@
 
         return fillColor;
       })
-      .style('stroke-width', geoConfig.borderWidth)
-      .style('stroke-opacity', geoConfig.borderOpacity)
-      .style('stroke', geoConfig.borderColor);
+      .style('stroke-width', function(d) {
+        var datum = colorCodeData[d.id];
+
+        return val(datum && datum.borderWidth, geoConfig.borderWidth, datum);
+      })
+      .style('stroke-opacity', function(d) {
+        var datum = colorCodeData[d.id];
+
+        return val(datum && datum.borderOpacity, geoConfig.borderOpacity, datum);
+      })
+      .style('stroke', function(d) {
+        var datum = colorCodeData[d.id];
+
+        return val(datum && datum.borderColor, geoConfig.borderColor, datum);
+      });
   }
 
   function handleGeographyConfig () {


### PR DESCRIPTION
Addresses Issues: https://github.com/markmarkoh/datamaps/issues/436 and https://github.com/markmarkoh/datamaps/issues/364

This PR adds the ability to supply `borderWidth`, `borderColor`, and `borderOpacity` with the map's data. This allows for custom strokes on states/countries. This does not update the border when `updateChoropleth` is called. I'll add that if this proposed change is accepted, I wanted to keep the delta low for now.

Example test screenshot:
![screen shot 2018-05-03 at 2 45 53 pm](https://user-images.githubusercontent.com/1791149/39596908-d61a02c0-4ee1-11e8-9ad2-c121acfb7af6.png)

Relavent code:
Current handling:
https://github.com/markmarkoh/datamaps/blob/master/src/js/datamaps.js#L213
How the plugins already allow this behavior:
https://github.com/markmarkoh/datamaps/blob/master/src/js/datamaps.js#L256

Note*: I think it would be nice to have something in the readme about the `data` option. I can work on that on another PR if that's desired.