### PR TITLE
Fix updateChoropleth Issues

### DIFF
--- a/src/js/datamaps.js
+++ b/src/js/datamaps.js
@@ -1126,12 +1126,18 @@
         // If it's an object, overriding the previous data
         if ( subunitData === Object(subunitData) ) {
           this.options.data[subunit] = defaults(subunitData, this.options.data[subunit] || {});
-          var geo = this.svg.select('.' + subunit).attr('data-info', JSON.stringify(this.options.data[subunit]));
+          var geo = this.svg.select('.' + CSS.escape(subunit)).attr('data-info', JSON.stringify(this.options.data[subunit]));
         }
         svg
-          .selectAll('.' + subunit)
+          .selectAll('.' + CSS.escape(subunit))
           .transition()
             .style('fill', color);
+      }
+    }
+    
+    for (var existingSubunit in this.options.data) {
+      if(this.options.data.hasOwnProperty(existingSubunit) && !data.hasOwnProperty(existingSubunit)) {
+        map.options.data[existingSubunit] = {};
       }
     }
   };


### PR DESCRIPTION
Allows numerical subunits in updateChoropleth and reloads subunits that had data previously but don't in the new data being passed to updateChoropleth.

Right now, subunits with numerical IDs (such as maps of US counties) cause an error when trying to run updateChoropleth because they're not valid CSS selectors. CSS.escape() escapes numbers to be used as selectors.

Also, if there is data for a subunit but you try to run updateChoropleth with new data that doesn't include that subunit it doesn't update its data to become blank, leaving some side-effects if you try to access their current fill colour, which updating them to be empty prevents.