### PR TITLE
Fix: TS types for DataMapOptions.fills

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ declare interface DataMapOptions {
     bubblesConfig?: DataMapBubblesConfigOptions;
     arcConfig?: DataMapArcConfigOptions;
     setProjection?: (element: HTMLElement, options: DataMapOptions) => DataMapProjection;
-    fills?: { defaultFill?: string, [key: string]: string };
+    fills?: { defaultFill?: string } & { [key: string]: string };
     done?: (datamap: {
         svg: d3.Selection<any>,
         options: DataMapOptions,


### PR DESCRIPTION
There is a bug in type definitions of `DataMapOptions.fills` with `Index signatures`.

```
ERROR in /Users/psvitek001/Projects/big/big-vuejs-fe/node_modules/datamaps/src/index.d.ts
10:15 Property 'defaultFill' of type 'string | undefined' is not assignable to string index type 'string'.
     8 |     arcConfig?: DataMapArcConfigOptions;z
     9 |     setProjection?: (element: HTMLElement, options: DataMapOptions) => DataMapProjection;
  > 10 |     fills?: { defaultFill?: string, [key: string]: string };
       |               ^
    11 |     done?: (datamap: {
    12 |         svg: d3.Selection<any>,
    13 |         options: DataMapOptions,
```

I encountered it in VueJS + Typescript project.

More explanation here, section `Excluding certain properties from the index signature`
https://basarat.gitbooks.io/typescript/docs/types/index-signatures.html