### PR TITLE
Correct the type of the `fills` mapping

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ declare interface DataMapOptions {
     bubblesConfig?: DataMapBubblesConfigOptions;
     arcConfig?: DataMapArcConfigOptions;
     setProjection?: (element: HTMLElement, options: DataMapOptions) => DataMapProjection;
-    fills?: { defaultFill?: string, [key: string]: string };
+    fills?: { defaultFill?: string, [key: string]: string | undefined };
     done?: (datamap: {
         svg: d3.Selection<any>,
         options: DataMapOptions,


### PR DESCRIPTION
For an optional `defaultFill` key, the general signature should be `string | undefined`. This is being catched when used with nuxt.