### PR TITLE
do save off default references also when creating a new datamap

### DIFF
--- a/dist/datamaps.world.js
+++ b/dist/datamaps.world.js
@@ -700,9 +700,12 @@
 
   function Datamap( options ) {
 
+    d3 = window.d3;
+    topojson = window.topojson;
+    
     if ( typeof d3 === 'undefined' || typeof topojson === 'undefined' ) {
       throw new Error('Include d3.js (v3.0.3 or greater) and topojson on this page before creating a new map');
-   }
+    }
     // Set options for global use
     this.options = defaults(options, defaultOptions);
     this.options.geographyConfig = defaults(options.geographyConfig, defaultOptions.geographyConfig);


### PR DESCRIPTION
also do `// Save off default references` step when instanciating a new datamap, to make it more stable when loading d3 and topojson dependencies after datamaps itself
I came across this issue when using nuxtjs and conditionally loading the external libraries in, idk if this is relevant in other situations too