### PR TITLE
Possible documentation fix regarding "fill"

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ You'll need to know the 2 letter state code ('NY' for New York) or the 3 letter 
 
 This will draw a world map and fill in IRL (Ireland) with the corresponding `fills.LOW` and USA with `fills.MEDIUM`.
 
-You can also use `fill: color` for each state if you don't want to define a `fillKey`.
+You can also use `{key: color}` (eg, `{CA: 'green'}) for each state if you don't want to define a `fillKey`.
 
 Colors will be applied in this order: `fillKey`, `fill`, `defaultFill`.
 


### PR DESCRIPTION
Hello! I tried using `fill` instead of `fillKey` as mentioned in the documentation but it didn't work for me.

**Didn't work**

```js
map.updateChoropleth({USA: {fill: 'green'} })
```


What _did_ work was to use the color directly, without the `fill` keyword, similar to an example given lower down in the documentation.

**Did work**

```js
map.updateChoropleth({USA: 'green'})
```

Therefore, I'm wondering if this is a mistake in the documentation?


Thanks!
